### PR TITLE
Use versioned filename for loading libgbm_kms

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -40,7 +40,7 @@
  * directory..
  */
 static const char *backends[] = {
-      "libgbm_kms.so",
+      "libgbm_kms.so.1",
 };
 
 static const void *


### PR DESCRIPTION
This will match the convention for library naming in many distributions, including yocto.

Fixes issue #1 
